### PR TITLE
Realistic thumbtack pin + wrap bio text around photo

### DIFF
--- a/images/pushpin.svg
+++ b/images/pushpin.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 86" width="64" height="86">
+  <defs>
+    <radialGradient id="head" cx="36%" cy="30%" r="78%">
+      <stop offset="0%" stop-color="#ff9d9d"/>
+      <stop offset="42%" stop-color="#e23b3b"/>
+      <stop offset="100%" stop-color="#8f1414"/>
+    </radialGradient>
+    <linearGradient id="neck" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c93636"/>
+      <stop offset="100%" stop-color="#7c1212"/>
+    </linearGradient>
+    <linearGradient id="needle" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#6c6c6c"/>
+      <stop offset="35%" stop-color="#f2f2f2"/>
+      <stop offset="62%" stop-color="#b0b0b0"/>
+      <stop offset="100%" stop-color="#5e5e5e"/>
+    </linearGradient>
+  </defs>
+  <!-- contact shadow where the needle enters -->
+  <ellipse cx="33" cy="83" rx="5" ry="2" fill="#000000" opacity="0.18"/>
+  <!-- metal needle -->
+  <polygon points="29,46 35,46 33.6,83 31.4,83" fill="url(#needle)"/>
+  <!-- neck under the head -->
+  <path d="M20 39 h24 a3 3 0 0 1 3 3 v2 a15 7 0 0 1 -30 0 v-2 a3 3 0 0 1 3 -3 z" fill="url(#neck)"/>
+  <!-- domed head -->
+  <ellipse cx="32" cy="26" rx="27" ry="23" fill="url(#head)"/>
+  <!-- glossy highlight -->
+  <ellipse cx="22" cy="16" rx="8.5" ry="5.5" fill="#ffffff" opacity="0.6"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
         <section id="about" class="hero fade-in">
             <div class="hero-content">
                 <div class="photo-frame">
-                    <span class="photo-pin" aria-hidden="true"></span>
+                    <img src="images/pushpin.svg" class="photo-pin" alt="" aria-hidden="true">
                     <img src="images/keyurpatel.jpeg" alt="Keyur Patel" class="hero-photo"
                         onerror="this.style.display='none'">
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -220,18 +220,23 @@ ul {
 /* hero-name removed by design */
 
 .hero-content {
-    display: flex;
-    gap: 40px;
-    align-items: center;
+    display: block;
 }
 
-/* Pinned photo frame */
+/* clear the floated photo */
+.hero-content::after {
+    content: '';
+    display: block;
+    clear: both;
+}
+
+/* Pinned photo frame — floated so the bio wraps around it */
 .photo-frame {
     position: relative;
-    flex-shrink: 0;
-    width: 210px;
-    padding-top: 10px;
-    transform: rotate(-1.2deg);
+    float: left;
+    width: 200px;
+    margin: 8px 38px 18px 0;
+    transform: rotate(-1.5deg);
     transition: transform 0.3s ease;
 }
 
@@ -241,7 +246,7 @@ ul {
 
 .hero-photo {
     width: 100%;
-    height: 250px;
+    height: 240px;
     border-radius: 4px;
     object-fit: cover;
     object-position: center top;
@@ -256,28 +261,13 @@ ul {
 /* Push-pin holding the photo */
 .photo-pin {
     position: absolute;
-    top: -2px;
+    top: -30px;
     left: 50%;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    transform: translateX(-50%);
-    background: radial-gradient(circle at 35% 28%, #ff9b9b 0%, #e23b3b 45%, #9e1818 100%);
-    box-shadow: 0 4px 6px rgba(74, 58, 35, 0.4), inset -1px -2px 3px rgba(0, 0, 0, 0.3);
+    width: 34px;
+    height: auto;
+    transform: translateX(-50%) rotate(6deg);
     z-index: 3;
-}
-
-/* glossy highlight on the pin */
-.photo-pin::after {
-    content: '';
-    position: absolute;
-    top: 4px;
-    left: 5px;
-    width: 7px;
-    height: 5px;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.85);
-    transform: rotate(-20deg);
+    filter: drop-shadow(0 4px 4px rgba(74, 58, 35, 0.35));
 }
 
 .hero-bio {
@@ -676,31 +666,23 @@ ul {
         font-size: 2rem;
     }
 
-    .hero-content {
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-    }
-
-    .hero-content {
-        gap: 28px;
-    }
-
     .photo-frame {
-        width: 180px;
+        width: 140px;
+        margin: 6px 22px 12px 0;
         transform: rotate(0deg);
     }
 
+    .photo-pin {
+        width: 28px;
+        top: -24px;
+    }
+
     .hero-photo {
-        height: 215px;
+        height: 170px;
     }
 
     .hero-bio {
         text-align: left;
-    }
-
-    .hero-links {
-        justify-content: center;
     }
 
     .timeline-logo {


### PR DESCRIPTION
- **Pin:** replaced the flat CSS circle with a detailed **thumbtack SVG** (`images/pushpin.svg`) — domed glossy head, neck, and a metal needle entering the photo. This environment blocks outbound image downloads, so I added a crisp local vector instead of hotlinking a remote PNG.
- **Layout:** the photo is now **floated** so the bio text wraps around it, removing the big empty gap (especially on mobile).
- Tuned photo and pin sizing for desktop and mobile.

https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ)_