### PR TITLE
Fix hero bio alignment (remove justify)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -271,11 +271,11 @@ ul {
 }
 
 .hero-bio {
-    flex: 1;
-    text-align: justify;
+    text-align: left;
     color: var(--ink-soft);
     font-size: 0.95rem;
     line-height: 1.8;
+    overflow-wrap: break-word;
 }
 
 .hero-bio strong {


### PR DESCRIPTION
The hero bio used `text-align: justify`, which — combined with the narrow column next to the floated photo and long technical terms — produced huge gaps between words. Switched to left-aligned and added `overflow-wrap: break-word` to keep long tokens in bounds.

https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ)_