### PR TITLE
Merge 'currently working with' into the skills card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,27 +375,25 @@
         <section id="skills" class="section fade-in">
             <h2 class="section-title">Technical Skills</h2>
 
-            <div class="skills-highlight">
-                <span class="skills-highlight-label">Currently working with</span>
-                <div class="marquee-tags">
-                    <span>AWS Bedrock</span>
-                    <span>Amazon Nova Sonic</span>
-                    <span>MCP</span>
-                    <span>Google ADK</span>
-                    <span>LangGraph</span>
-                    <span>AWS Strands</span>
-                </div>
-            </div>
-
             <div class="skills-grid">
+                <div class="skill-category skill-category--current fade-in">
+                    <h3>⭐ Currently Working With</h3>
+                    <ul>
+                        <li>AWS Bedrock</li>
+                        <li>Amazon Nova Sonic (Voice)</li>
+                        <li>Google ADK</li>
+                        <li>MCP & A2A Protocols</li>
+                        <li>LangGraph & AWS Strands</li>
+                    </ul>
+                </div>
                 <div class="skill-category fade-in">
                     <h3>🤖 Agentic AI</h3>
                     <ul>
-                        <li>Google ADK</li>
-                        <li>MCP (Model Context Protocol)</li>
-                        <li>A2A Protocol</li>
-                        <li>LangChain & LangGraph</li>
-                        <li>AWS Strands</li>
+                        <li>Multi-Agent Orchestration</li>
+                        <li>Tool Use & Function Calling</li>
+                        <li>Agent Evaluation & Tracing</li>
+                        <li>Guardrails & Observability</li>
+                        <li>LangChain</li>
                     </ul>
                 </div>
                 <div class="skill-category fade-in">

--- a/styles.css
+++ b/styles.css
@@ -587,36 +587,6 @@ ul {
 }
 
 /* === Skills === */
-.skills-highlight {
-    margin-bottom: 30px;
-}
-
-.skills-highlight-label {
-    display: block;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--accent);
-    margin-bottom: 12px;
-}
-
-.marquee-tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-}
-
-.marquee-tags span {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #fff;
-    background: var(--accent);
-    padding: 5px 14px;
-    border-radius: 999px;
-    box-shadow: 0 2px 6px rgba(154, 111, 46, 0.25);
-}
-
 .skills-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
@@ -643,6 +613,14 @@ ul {
     font-size: 0.85rem;
     color: var(--ink-soft);
     padding: 3px 0;
+}
+
+/* Highlighted "currently working with" card */
+.skill-category--current {
+    background: rgba(154, 111, 46, 0.07);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px 18px;
 }
 
 /* === Awards === */


### PR DESCRIPTION
The solid accent pill row looked out of place against the card-based Skills grid. Replaced it with a first **"⭐ Currently Working With"** card that matches the existing skill-category styling, with a subtle accent tint so it still reads as the highlight. Also de-duplicated the "Agentic AI" card (now concepts: orchestration, tool use, evals, guardrails) since the tool names moved into the current-focus card.

https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ)_