### PR TITLE
Remove availability status badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,8 +105,6 @@
                         production scale.
                     </p>
 
-                    <span class="hero-status"><span class="dot"></span> Open to advisory &amp; consulting</span>
-
                     <p class="hero-bio">
                         I'm a Sr. AI Engineer at <strong>T-Mobile USA</strong> with over a decade in software
                         engineering, now focused on Agentic AI. I build real-time voice agents on

--- a/styles.css
+++ b/styles.css
@@ -268,28 +268,6 @@ ul {
     margin-bottom: 14px;
 }
 
-.hero-status {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--accent-dark);
-    background: rgba(154, 111, 46, 0.1);
-    border: 1px solid var(--border);
-    padding: 4px 13px;
-    border-radius: 999px;
-    margin-bottom: 18px;
-}
-
-.hero-status .dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #4a8f5b;
-    box-shadow: 0 0 0 3px rgba(74, 143, 91, 0.18);
-}
-
 .hero-bio {
     text-align: left;
     color: var(--ink-soft);


### PR DESCRIPTION
Removed the "Open to advisory & consulting" status badge from the hero (and its now-unused CSS) per request.

https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ)_