### PR TITLE
Replace emojis with Lucide icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                 </div>
             </div>
 
-            <button class="mobile-menu-btn" id="mobile-menu-btn">☰</button>
+            <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Menu"><i data-lucide="menu"></i></button>
         </div>
 
         <!-- Mobile Menu -->
@@ -375,7 +375,7 @@
 
             <div class="skills-grid">
                 <div class="skill-category skill-category--current fade-in">
-                    <h3>⭐ Currently Working With</h3>
+                    <h3><i data-lucide="sparkles"></i> Currently Working With</h3>
                     <ul>
                         <li>AWS Bedrock</li>
                         <li>Amazon Nova Sonic (Voice)</li>
@@ -385,7 +385,7 @@
                     </ul>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3>🤖 Agentic AI</h3>
+                    <h3><i data-lucide="bot"></i> Agentic AI</h3>
                     <ul>
                         <li>Multi-Agent Orchestration</li>
                         <li>Tool Use & Function Calling</li>
@@ -395,7 +395,7 @@
                     </ul>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3>🧠 Generative AI</h3>
+                    <h3><i data-lucide="brain-circuit"></i> Generative AI</h3>
                     <ul>
                         <li>Large Language Models</li>
                         <li>Agent Orchestration</li>
@@ -403,7 +403,7 @@
                     </ul>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3>⚙️ Backend</h3>
+                    <h3><i data-lucide="server"></i> Backend</h3>
                     <ul>
                         <li>Microservices</li>
                         <li>API Development</li>
@@ -412,7 +412,7 @@
                     </ul>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3>☁️ Cloud & DevOps</h3>
+                    <h3><i data-lucide="cloud"></i> Cloud & DevOps</h3>
                     <ul>
                         <li>AWS · Azure · GCP</li>
                         <li>Docker & Kubernetes</li>
@@ -421,7 +421,7 @@
                     </ul>
                 </div>
                 <div class="skill-category fade-in">
-                    <h3>🗄️ Data & Web</h3>
+                    <h3><i data-lucide="database"></i> Data & Web</h3>
                     <ul>
                         <li>Cassandra · MySQL · PostgreSQL</li>
                         <li>MongoDB</li>
@@ -440,11 +440,11 @@
                 <div class="fade-in">
                     <h3 style="font-size:1rem; font-weight:700; margin-bottom:12px;">Awards & Certifications</h3>
                     <ul class="awards-list">
-                        <li><span class="icon">🏅</span> AiSera AI Workflows (Intermediate) — 2024</li>
-                        <li><span class="icon">🏅</span> Microsoft Power BI DAT207X — 2019</li>
-                        <li><span class="icon">🏅</span> Certified Blockchain Expert™ — 2019</li>
-                        <li><span class="icon">🏆</span> 1st Place — 2018 Sogeti Devops Hackathon</li>
-                        <li><span class="icon">🏆</span> 1st Place — 2013 Nationwide AT&T Coding Challenge</li>
+                        <li><i data-lucide="medal" class="icon"></i> AiSera AI Workflows (Intermediate) — 2024</li>
+                        <li><i data-lucide="medal" class="icon"></i> Microsoft Power BI DAT207X — 2019</li>
+                        <li><i data-lucide="medal" class="icon"></i> Certified Blockchain Expert™ — 2019</li>
+                        <li><i data-lucide="trophy" class="icon"></i> 1st Place — 2018 Sogeti Devops Hackathon</li>
+                        <li><i data-lucide="trophy" class="icon"></i> 1st Place — 2013 Nationwide AT&T Coding Challenge</li>
                     </ul>
                 </div>
                 <div class="fade-in">
@@ -502,6 +502,7 @@
     }
     </script>
 
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
     <script src="script.js"></script>
 </body>
 

--- a/script.js
+++ b/script.js
@@ -3,18 +3,21 @@ const mobileMenuButton = document.getElementById('mobile-menu-btn');
 const mobileMenu = document.getElementById('mobile-menu');
 
 if (mobileMenuButton && mobileMenu) {
+    const setMenuIcon = (name) => {
+        mobileMenuButton.innerHTML = `<i data-lucide="${name}"></i>`;
+        if (window.lucide) lucide.createIcons();
+    };
+
     mobileMenuButton.addEventListener('click', () => {
-        mobileMenu.classList.toggle('open');
-        // Toggle hamburger icon
-        const icon = mobileMenuButton.textContent.trim();
-        mobileMenuButton.textContent = icon === '☰' ? '✕' : '☰';
+        const isOpen = mobileMenu.classList.toggle('open');
+        setMenuIcon(isOpen ? 'x' : 'menu');
     });
 
     // Close mobile menu when a link is clicked
     mobileMenu.querySelectorAll('a').forEach(link => {
         link.addEventListener('click', () => {
             mobileMenu.classList.remove('open');
-            mobileMenuButton.textContent = '☰';
+            setMenuIcon('menu');
         });
     });
 }
@@ -36,3 +39,8 @@ const observer = new IntersectionObserver((entries) => {
 fadeTargets.forEach(target => {
     observer.observe(target);
 });
+
+// Render Lucide icons (replaces [data-lucide] placeholders with inline SVGs)
+if (window.lucide) {
+    lucide.createIcons();
+}

--- a/styles.css
+++ b/styles.css
@@ -181,9 +181,15 @@ ul {
     background: none;
     border: none;
     color: var(--ink);
-    font-size: 1.5rem;
     cursor: pointer;
     padding: 4px;
+    line-height: 0;
+}
+
+.mobile-menu-btn svg {
+    width: 26px;
+    height: 26px;
+    stroke-width: 2;
 }
 
 .mobile-menu {
@@ -572,6 +578,9 @@ ul {
 }
 
 .skill-category h3 {
+    display: flex;
+    align-items: center;
+    gap: 9px;
     font-size: 0.95rem;
     font-weight: 700;
     color: var(--ink);
@@ -580,6 +589,14 @@ ul {
     margin-bottom: 8px;
     padding-bottom: 4px;
     border-bottom: 2px solid var(--accent);
+}
+
+.skill-category h3 svg {
+    width: 18px;
+    height: 18px;
+    color: var(--accent);
+    stroke-width: 2;
+    flex-shrink: 0;
 }
 
 .skill-category ul {
@@ -622,8 +639,13 @@ ul {
     gap: 8px;
 }
 
-.awards-list .icon {
-    font-size: 1rem;
+.awards-list .icon,
+.awards-list li svg {
+    width: 18px;
+    height: 18px;
+    color: var(--accent);
+    stroke-width: 2;
+    flex-shrink: 0;
 }
 
 .interests-text {


### PR DESCRIPTION
Replaced all emojis with **Lucide** line icons for a more refined, consistent look:

- Skill headers: 🤖→`bot`, 🧠→`brain-circuit`, ⚙️→`server`, ☁️→`cloud`, 🗄️→`database`, ⭐→`sparkles`
- Awards: 🏅→`medal`, 🏆→`trophy`
- Mobile menu: ☰/✕ glyphs → `menu`/`x` icons (toggled in JS)
- All icons inherit the ochre accent color and align cleanly with their labels
- Lucide loaded via CDN and rendered with `lucide.createIcons()`; guarded so it degrades gracefully if the script doesn't load

Note: icons render from a CDN (`unpkg`) in the visitor's browser. If you'd prefer zero external dependencies, I can inline the specific SVGs instead — just say so.

https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ)_