### PR TITLE
Add Connected Agents Summit award, remove dated certs

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,13 +438,11 @@
 
             <div class="awards-grid">
                 <div class="fade-in">
-                    <h3 style="font-size:1rem; font-weight:700; margin-bottom:12px;">Awards & Certifications</h3>
+                    <h3 style="font-size:1rem; font-weight:700; margin-bottom:12px;">Awards & Recognition</h3>
                     <ul class="awards-list">
-                        <li><i data-lucide="medal" class="icon"></i> AiSera AI Workflows (Intermediate) — 2024</li>
-                        <li><i data-lucide="medal" class="icon"></i> Microsoft Power BI DAT207X — 2019</li>
-                        <li><i data-lucide="medal" class="icon"></i> Certified Blockchain Expert™ — 2019</li>
-                        <li><i data-lucide="trophy" class="icon"></i> 1st Place — 2018 Sogeti Devops Hackathon</li>
-                        <li><i data-lucide="trophy" class="icon"></i> 1st Place — 2013 Nationwide AT&T Coding Challenge</li>
+                        <li><i data-lucide="award" class="icon"></i> <span><strong>Best Agent — Business Impact &amp; Value</strong> · Microsoft Connected Agents Summit — 2026</span></li>
+                        <li><i data-lucide="trophy" class="icon"></i> <span>1st Place — 2018 Sogeti DevOps Hackathon</span></li>
+                        <li><i data-lucide="trophy" class="icon"></i> <span>1st Place — 2013 Nationwide AT&amp;T Coding Challenge</span></li>
                     </ul>
                 </div>
                 <div class="fade-in">

--- a/styles.css
+++ b/styles.css
@@ -635,8 +635,9 @@ ul {
     font-size: 0.9rem;
     color: var(--ink-soft);
     display: flex;
-    align-items: center;
-    gap: 8px;
+    align-items: flex-start;
+    gap: 9px;
+    line-height: 1.5;
 }
 
 .awards-list .icon,
@@ -646,6 +647,7 @@ ul {
     color: var(--accent);
     stroke-width: 2;
     flex-shrink: 0;
+    margin-top: 2px;
 }
 
 .interests-text {


### PR DESCRIPTION
- Added the new award at the top with an `award` (rosette) icon: **Best Agent — Business Impact & Value · Microsoft Connected Agents Summit — 2026**
- Removed all three certifications (Power BI DAT207X 2019, Certified Blockchain Expert 2019, AiSera AI Workflows 2024) per request
- Renamed the section heading from "Awards & Certifications" → **"Awards & Recognition"** (no certs left)
- Kept the two 1st-place hackathon/coding wins
- Adjusted list alignment so a multi-line award entry sits cleanly next to its icon

https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ)_