### PR TITLE
Straighten photo, flatten skills highlight, 3-per-row grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@
             <h2 class="section-title">Technical Skills</h2>
 
             <div class="skills-grid">
-                <div class="skill-category skill-category--current fade-in">
+                <div class="skill-category fade-in">
                     <h3><i data-lucide="sparkles"></i> Currently Working With</h3>
                     <ul>
                         <li>AWS Bedrock</li>

--- a/styles.css
+++ b/styles.css
@@ -236,18 +236,12 @@ ul {
     clear: both;
 }
 
-/* Pinned photo frame — floated so the bio wraps around it */
+/* Photo frame — floated so the bio wraps around it */
 .photo-frame {
     position: relative;
     float: left;
     width: 200px;
     margin: 8px 38px 18px 0;
-    transform: rotate(-1.5deg);
-    transition: transform 0.3s ease;
-}
-
-.photo-frame:hover {
-    transform: rotate(0deg);
 }
 
 .hero-photo {
@@ -573,7 +567,7 @@ ul {
 /* === Skills === */
 .skills-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 24px;
 }
 
@@ -608,14 +602,6 @@ ul {
     font-size: 0.85rem;
     color: var(--ink-soft);
     padding: 3px 0;
-}
-
-/* Highlighted "currently working with" card */
-.skill-category--current {
-    background: rgba(154, 111, 46, 0.07);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px 18px;
 }
 
 /* === Awards === */
@@ -699,7 +685,6 @@ ul {
     .photo-frame {
         width: 140px;
         margin: 6px 22px 12px 0;
-        transform: rotate(0deg);
     }
 
     .hero-photo {


### PR DESCRIPTION
- **Photo:** removed the tilt (and hover-straighten) — it now sits straight
- **Skills:** removed the accent box highlight on the "Currently Working With" card so it matches every other card
- **Skills grid:** now exactly 3 cards per row on desktop (still 2 on tablet, 1 on mobile)

Projects: AI Agent Harness and CareerVector remain Live-Demo-only (no public repos) since the code is proprietary.

https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015avG4tcLp9JSQaVkDDn8PQ)_